### PR TITLE
disable the FXOS8700 accelerometer

### DIFF
--- a/boards/mimxrt1024_evk.overlay
+++ b/boards/mimxrt1024_evk.overlay
@@ -21,3 +21,10 @@
 		reg = <0x76>;
 	};
 };
+
+&lpi2c4 {
+	fxos8700: fxos8700@1f {
+		/* This sensor is not populated on the evaluation kit */
+		status = "disabled";
+	};
+};


### PR DESCRIPTION
The accelerometer is not populated on the mimxrt1024_evk. Disabling this node prevents the WHOAMI error at boot:

```
[00:00:00.512,000] <err> FXOS8700: Could not get WHOAMI value
```